### PR TITLE
Reset password option

### DIFF
--- a/firstuseauthenticator/templates/reset.html
+++ b/firstuseauthenticator/templates/reset.html
@@ -1,0 +1,54 @@
+{% extends "page.html" %}
+
+{% block main %}
+
+<div class="container">
+<form action="{{login_url}}?next={{next}}" method="post" role="form">
+  <div class="auth-form-header">
+    Sign in
+  </div>
+  <div class='auth-form-body'>
+
+    <p id='insecure-login-warning' class='hidden'>
+    Warning: JupyterHub seems to be served over an unsecured HTTP connection.
+    We strongly recommend enabling HTTPS for JupyterHub.
+    </p>
+
+    {% if login_error %}
+    <p class="login_error">
+      {{login_error}}
+    </p>
+    {% endif %}
+    <label for="username_input">Username:</label>
+    <input
+      id="username_input"
+      type="text"
+      autocapitalize="off"
+      autocorrect="off"
+      class="form-control"
+      name="username"
+      val="{{username}}"
+      tabindex="1"
+      autofocus="autofocus"
+    />
+    <label for='password_input'>Password:</label>
+    <input
+      type="password"
+      class="form-control"
+      name="password"
+      id="password_input"
+      tabindex="2"
+    />
+
+    <input
+      type="submit"
+      id="login_submit"
+      class='btn btn-jupyter'
+      value='Sign In'
+      tabindex="3"
+    />
+  </div>
+</form>
+</div>
+
+{% endblock %}

--- a/firstuseauthenticator/templates/reset.html
+++ b/firstuseauthenticator/templates/reset.html
@@ -3,35 +3,14 @@
 {% block main %}
 
 <div class="container">
-<form action="{{login_url}}?next={{next}}" method="post" role="form">
-  <div class="auth-form-header">
-    Sign in
-  </div>
+<form action="{{post_url}}" method="post" role="form">
+  <h2 class="auth-form-header">
+    Change Password
+  </h2>
   <div class='auth-form-body'>
 
-    <p id='insecure-login-warning' class='hidden'>
-    Warning: JupyterHub seems to be served over an unsecured HTTP connection.
-    We strongly recommend enabling HTTPS for JupyterHub.
-    </p>
 
-    {% if login_error %}
-    <p class="login_error">
-      {{login_error}}
-    </p>
-    {% endif %}
-    <label for="username_input">Username:</label>
-    <input
-      id="username_input"
-      type="text"
-      autocapitalize="off"
-      autocorrect="off"
-      class="form-control"
-      name="username"
-      val="{{username}}"
-      tabindex="1"
-      autofocus="autofocus"
-    />
-    <label for='password_input'>Password:</label>
+    <label for='password_input'>New Password:</label>
     <input
       type="password"
       class="form-control"
@@ -49,6 +28,11 @@
     />
   </div>
 </form>
+{% if result %}
+  <p>
+    {{result_message}}
+  </p>
+{% endif %}
 </div>
 
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,8 @@ setup(
     author_email='yuvipanda@gmail.com',
     license='3 Clause BSD',
     packages=find_packages(),
-    install_requires=['bcrypt']
+    install_requires=['bcrypt'],
+    package_data={
+        '': ['*.html'],
+    }
 )


### PR DESCRIPTION
This implements a new url where the logged user can change the original password to a new one.

This was done based on comments made on [this issue](https://github.com/jupyterhub/outreachy/issues/2).

To test it (manually):
* install this version 
* login to jupyterhub
* go to `/hub/auth/change-password` 
* create a new password
* logout and login again with the new password