### PR TITLE
Catch deletion of users that have not logged in

### DIFF
--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -124,8 +124,11 @@ class FirstUseAuthenticator(Authenticator):
 
         This lets passwords be reset by deleting users.
         """
-        with dbm.open(self.dbm_path, 'c', 0o600) as db:
-            db.pop(user.name, None)
+        try:
+            with dbm.open(self.dbm_path, 'c', 0o600) as db:
+                del db[user.name]
+        except KeyError as k:
+            pass
 
     def reset_password(self, username, new_password):
         """

--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -125,7 +125,7 @@ class FirstUseAuthenticator(Authenticator):
         This lets passwords be reset by deleting users.
         """
         with dbm.open(self.dbm_path, 'c', 0o600) as db:
-            del db[user.name]
+            db.pop(user.name, None)
 
     def reset_password(self, username, new_password):
         """


### PR DESCRIPTION
This uses `dict.pop()` instead of `del` in order to not fail if a user has not yet created an entry in the db file.

Fixes #15 