### PR TITLE
fixed 'change password' feature for Jupyterhub version 1.0.0

### DIFF
--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -48,7 +48,7 @@ class ResetPasswordHandler(BaseHandler):
 
     @web.authenticated
     async def post(self):
-        user = self.get_current_user()
+        user = self.current_user
         new_password = self.get_body_argument('password', strip=False)
         self.authenticator.reset_password(user.name, new_password)
 


### PR DESCRIPTION
Trying to use firstuseauthenticator with Jupyterhub version 1.0.0 locally I had a problem when I tested password change.
Unfortunately, I don't remember in which other issue I found the explanation that I used to apply the change to the code but I tested it and it seems to work.
It is my first try of a contribution so please be patient if there is something missing in the contribution procedure.

The error I had in jupyterhub logs with the last version of the code (0.12) was:
```
I 2019-08-24 08:35:26.827 JupyterHub log:174] 200 POST /hub/api/oauth2/token (alessandro@172.20.0.4) 41.31ms
jupyterhub | [I 2019-08-24 08:35:26.863 JupyterHub log:174] 200 GET /hub/api/authorizations/token/[secret] (alessandro@172.20.0.4) 30.91ms
jupyterhub | [I 2019-08-24 08:35:57.028 JupyterHub log:174] 200 GET /hub/auth/change-password (alessandro@172.20.0.3) 38.91ms
jupyterhub | [E 2019-08-24 08:36:02.139 JupyterHub web:1788] Uncaught exception POST /hub/auth/change-password (172.20.0.3)
jupyterhub |     HTTPServerRequest(protocol='http', host='127.0.0.1:8080', method='POST', uri='/hub/auth/change-password', version='HTTP/1.1', remote_ip='172.20.0.3')
jupyterhub |     Traceback (most recent call last):
jupyterhub |       File "/opt/conda/lib/python3.6/site-packages/tornado/web.py", line 1699, in _execute
jupyterhub |         result = await result
jupyterhub |       File "/opt/conda/lib/python3.6/site-packages/firstuseauthenticator/firstuseauthenticator.py", line 53, in post
jupyterhub |         self.authenticator.reset_password(user.name, new_password)
jupyterhub |     AttributeError: 'coroutine' object has no attribute 'name'
jupyterhub |     
jupyterhub | [E 2019-08-24 08:36:02.151 JupyterHub log:166] {
jupyterhub |       "Upgrade-Insecure-Requests": "1",
jupyterhub |       "Cookie": "jupyterhub-hub-login=[secret]; jupyterhub-session-id=[secret]; _xsrf=[secret]",
jupyterhub |       "Connection": "close",
jupyterhub |       "Content-Length": "16",
jupyterhub |       "Content-Type": "application/x-www-form-urlencoded",
jupyterhub |       "Referer": "http://127.0.0.1:8080/hub/auth/change-password",
jupyterhub |       "Accept-Encoding": "gzip, deflate",
jupyterhub |       "Accept-Language": "en-US,en;q=0.5",
jupyterhub |       "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
jupyterhub |       "User-Agent": "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0",
jupyterhub |       "Host": "127.0.0.1:8080"
jupyterhub |     }
```
After the fix I have:

```
jupyterhub | [I 2019-08-24 08:49:42.041 JupyterHub log:174] 200 POST /hub/api/oauth2/token (ale@172.20.0.4) 44.71ms
jupyterhub | [I 2019-08-24 08:49:42.080 JupyterHub log:174] 200 GET /hub/api/authorizations/token/[secret] (ale@172.20.0.4) 31.65ms
jupyterhub | [I 2019-08-24 08:49:46.352 JupyterHub log:174] 200 GET /hub/auth/change-password (ale@172.20.0.3) 35.87ms
jupyterhub | [I 2019-08-24 08:49:50.866 JupyterHub log:174] 200 POST /hub/auth/change-password (ale@172.20.0.3) 263.09ms
```

and the web page correctly says password changed instead of internal server error 500