### PR TITLE
Prepare v0.13 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,20 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade . -r dev-requirements.txt
   - pip freeze
 script:
   - pytest
+deploy:
+  provider: pypi
+  user: "__token__"
+  # password: set by TravisCI's environment variable PYPI_PASSWORD
+  distributions: sdist bdist_wheel
+  on:
+    # Only deploy on tagged commits instead of the default of only doing it to
+    # the master branch. A tag does not belong specifically to a branch, so
+    # without this it would fail to deploy for tags.
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
 language: python
 dist: xenial
-python:
-  - 3.5
-  - 3.6
-  - 3.7
-  - 3.8
+
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade . -r dev-requirements.txt
   - pip freeze
+
 script:
   - pytest
-deploy:
-  provider: pypi
-  user: "__token__"
-  # password: set by TravisCI's environment variable PYPI_PASSWORD
-  distributions: sdist bdist_wheel
-  on:
-    # Only deploy on tagged commits instead of the default of only doing it to
-    # the master branch. A tag does not belong specifically to a branch, so
-    # without this it would fail to deploy for tags.
-    tags: true
+
+jobs:
+  fast_finish: true
+  include:
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+    # Only deploy if all test jobs passed
+    - stage: deploy
+      python: 3.7
+      if: tag IS present
+      deploy:
+        provider: pypi
+        user: __token__
+        # password: set by TravisCI's environment variable PYPI_PASSWORD
+        distributions: sdist bdist_wheel
+        on:
+          # Without this we get the note about:
+          # Skipping a deployment with the pypi provider because this branch is not permitted: <tag>
+          tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changes in firstuseauthenticator
+
+
+For detailed changes from the prior release, click on the version number, and
+its link will bring up a GitHub listing of changes. Use `git log` on the
+command line for details.
+
+## [Unreleased]
+
+* fixed 'change password' feature for Jupyterhub version 1.0.0 [#23](https://github.com/jupyterhub/firstuseauthenticator/pull/23) ([@ABVitali](https://github.com/ABVitali))
+* Update packages in tests [#22](https://github.com/jupyterhub/firstuseauthenticator/pull/22) ([@minrk](https://github.com/minrk))
+
+## [0.12] - 2019-01-24
+
+* Catch deletion of users that have not logged in [#16](https://github.com/jupyterhub/firstuseauthenticator/pull/16) ([@willirath](https://github.com/willirath))
+
+## [0.11.1] - 2019-01-24
+
+* add missing parameter to call of validate_user() [#12](https://github.com/jupyterhub/firstuseauthenticator/pull/12) ([@stv0g](https://github.com/stv0g))
+* add name sanitization [#11](https://github.com/jupyterhub/firstuseauthenticator/pull/11) ([@leportella](https://github.com/leportella))
+* add question on how to change password [#10](https://github.com/jupyterhub/firstuseauthenticator/pull/10) ([@leportella](https://github.com/leportella))
+* add basic tests [#9](https://github.com/jupyterhub/firstuseauthenticator/pull/9) ([@minrk](https://github.com/minrk))
+* Add option to change password [#8](https://github.com/jupyterhub/firstuseauthenticator/pull/8) ([@leportella](https://github.com/leportella))
+* Clean password db when user is deleted [#7](https://github.com/jupyterhub/firstuseauthenticator/pull/7) ([@yuvipanda](https://github.com/yuvipanda))
+
+## 0.11 - 2018-09-04
+* First release
+
+[Unreleased]: https://github.com/jupyterhub/firstuseauthenticator/compare/v0.12...d032b7f4bd22ee7e3a63d3ad41c0fea8c1fd7e37
+[0.11.1]: https://github.com/jupyterhub/firstuseauthenticator/compare/v0.11...v0.11.1
+[0.12]: https://github.com/jupyterhub/firstuseauthenticator/compare/v0.11...v0.12

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,9 +27,9 @@ repository](https://github.com/jupyterhub/firstuseauthenticator).
    [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
    utility.
 
-1. Set the `version_info` variable in [_version.py](firstuseauthenticator/_version.py)
+1. Set the `version_info` variable in [\_version.py](firstuseauthenticator/_version.py)
    appropriately and make a commit.
-   
+
    ```shell
    git add firstuseauthenticator/_version.py
    VERSION=...  # e.g. 1.2.3
@@ -37,9 +37,9 @@ repository](https://github.com/jupyterhub/firstuseauthenticator).
    ```
 
 1. Reset the `version_info` variable in
-   [_version.py](firstuseauthenticator/_version.py) appropriately with an incremented
+   [\_version.py](firstuseauthenticator/_version.py) appropriately with an incremented
    patch version and a `dev` element, then make a commit.
-   
+
    ```shell
    git add firstuseauthenticator/_version.py
    git commit -m "back to dev"
@@ -67,3 +67,4 @@ repository](https://github.com/jupyterhub/firstuseauthenticator).
    # then push it
    git push $ORIGIN refs/tags/$VERSION
    ```
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,69 @@
+# How to make a release
+
+`firstuseauthenticator` is a package [available on
+PyPI](https://pypi.org/project/jupyterhub-firstuseauthenticator/).
+The PyPI release is done automatically by TravisCI when a tag
+is pushed.
+
+For you to follow along according to these instructions, you need
+to have push rights to the [firstuseauthenticator GitHub
+repository](https://github.com/jupyterhub/firstuseauthenticator).
+
+## Steps to make a release
+
+1. Checkout master and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Update [CHANGELOG.md](CHANGELOG.md). Doing this can be made easier with the
+   help of the
+   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
+   utility.
+
+1. Set the `version_info` variable in [_version.py](firstuseauthenticator/_version.py)
+   appropriately and make a commit.
+   
+   ```shell
+   git add firstuseauthenticator/_version.py
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   ```
+
+1. Reset the `version_info` variable in
+   [_version.py](firstuseauthenticator/_version.py) appropriately with an incremented
+   patch version and a `dev` element, then make a commit.
+   
+   ```shell
+   git add firstuseauthenticator/_version.py
+   git commit -m "back to dev"
+   ```
+
+1. Push your two commits to master.
+
+   ```shell
+   # first push commits without a tags to ensure the
+   # commits comes through, because a tag can otherwise
+   # be pushed all alone without company of rejected
+   # commits, and we want have our tagged release coupled
+   # with a specific commit in master
+   git push $ORIGIN master
+   ```
+
+1. Create a git tag for the pushed release commit and push it.
+
+   ```shell
+   git tag -a $VERSION -m $VERSION HEAD~1
+
+   # then verify you tagged the right commit
+   git log
+
+   # then push it
+   git push $ORIGIN refs/tags/$VERSION
+   ```

--- a/firstuseauthenticator/_version.py
+++ b/firstuseauthenticator/_version.py
@@ -1,0 +1,15 @@
+"""firstuseauthenticator version info"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+version_info = (
+    0,
+    13,
+    0,
+    'dev',  # comment-out this line for a release
+)
+__version__ = '.'.join(map(str, version_info[:3]))
+
+if len(version_info) > 3:
+    __version__ = '%s%s' % (__version__, version_info[3])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'firstuseauthenticator', '_version.py')) as f:
 
 setup(
     name='jupyterhub-firstuseauthenticator',
-    version=version_ns['__version__'],,
+    version=version_ns['__version__'],
     description='JupyterHub Authenticator that lets users set passwords on first use',
     url='https://github.com/yuvipanda/jupyterhub-firstuseauthenticator',
     author='Yuvi Panda',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
+import os
+
 from setuptools import setup, find_packages
+
+# Get the current package version.
+here = os.path.abspath(os.path.dirname(__file__))
+version_ns = {}
+with open(os.path.join(here, 'firstuseauthenticator', '_version.py')) as f:
+    exec(f.read(), {}, version_ns)
 
 setup(
     name='jupyterhub-firstuseauthenticator',
-    version='0.12',
+    version=version_ns['__version__'],,
     description='JupyterHub Authenticator that lets users set passwords on first use',
     url='https://github.com/yuvipanda/jupyterhub-firstuseauthenticator',
     author='Yuvi Panda',


### PR DESCRIPTION
Preparing the release of FirstUseAuthenticator v0.13.

Thanks to the amazing work done in oauthenticator and chartpress (:heart:), we can follow the same release pattern for FirstUseAuthenticator.

ToDos: 
- [x] release tagged builds to PyPi using Travis
- [x] add a changelog.md
- [x] add a release.md describing the release steps

Closes https://github.com/jupyterhub/firstuseauthenticator/issues/26