### PR TITLE
lowercase username to lock password

### DIFF
--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -138,7 +138,7 @@ class FirstUseAuthenticator(Authenticator):
 
     @gen.coroutine
     def authenticate(self, handler, data):
-        username = data['username']
+        username = data['username'].lower()
 
         if not self.create_users:
             if not self._user_exists(username):


### PR DESCRIPTION
Prevent username with changed capitalization from taking over an existing username/password combination.

Root cause: jupyterhub lower-cases username, but firstuseauthenticator does not. So alternate capitalization of username gains access to,  and locks out, previous user.