### PR TITLE
Revert authenticate being made sync from async

### DIFF
--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -136,7 +136,7 @@ class FirstUseAuthenticator(Authenticator):
             return False
         return super().validate_username(name)
 
-    def authenticate(self, handler, data):
+    async def authenticate(self, handler, data):
         username = self.normalize_username(data['username'])
 
         if not self.create_users:


### PR DESCRIPTION
In #41 a change was made to remove @gen.coroutine from the authenticate function, but then our test suite started failing that assumed it to be async. I'm not sure if it's required to be async or not and we instead should update our tests.

I've opted to avoid that complexity by making it async instead for now.