### PR TITLE
default: allow all users if allowed_users is unspecified

### DIFF
--- a/firstuseauthenticator/firstuseauthenticator.py
+++ b/firstuseauthenticator/firstuseauthenticator.py
@@ -17,7 +17,7 @@ from jupyterhub.handlers import LoginHandler
 from jupyterhub.orm import User
 
 from tornado import web
-from traitlets.traitlets import Unicode, Bool, Integer
+from traitlets import default, Unicode, Bool, Integer
 
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
@@ -295,6 +295,13 @@ class FirstUseAuthenticator(Authenticator):
         if any((char in name) for char in invalid_chars):
             return False
         return super().validate_username(name)
+
+    @default("allow_all")
+    def _allow_all_default(self):
+        # the default behavior: allow all users
+        # if allowed_users is unspecified
+        # only affects JupyterHub >=5
+        return (not self.allowed_users)
 
     async def authenticate(self, handler, data):
         username = self.normalize_username(data["username"])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# automatically run coroutine tests with asyncio
+asyncio_mode = auto

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -8,14 +8,9 @@ import pytest
 from firstuseauthenticator import FirstUseAuthenticator
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def tmpcwd(tmpdir):
     tmpdir.chdir()
-
-# use pytest-asyncio
-pytestmark = pytest.mark.asyncio
-# run each test in a temporary working directory
-pytestmark = pytestmark(pytest.mark.usefixtures("tmpcwd"))
 
 
 async def test_basic(tmpcwd):


### PR DESCRIPTION
preserves pre-jupyterhub 5 default behavior, which makes sense for this Authenticator, even though the base class default has changed